### PR TITLE
Add automatic generation of rendered text when stored rendered is empty for Fixture issue.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -4,3 +4,4 @@ Carl J Meyer <carl@dirtcircle.com> - simplified widgets.py
 Michael Fladischer - test patch & debian packaging
 Javed Khan - escape_html option
 Roman Vasiliev - fix for South
+Alisue <lambdalisue@hashnote.net> - update rendered field when rendered is empty. required for fixture updating.


### PR DESCRIPTION
Duaring loaddata, `pre_save` method is not called that's why if you
want to create DEMO value or whatever with Fixture, empty field is
created.

To slove this issue, I change `_get_rendered` behavior to generate
rendered text automatically when stored rendered text is empty.

With this change, you can use fixture to create (but not update) field.
