### PR TITLE
Fix the migration problem of #20 (fields added twice)

### DIFF
--- a/markupfield/fields.py
+++ b/markupfield/fields.py
@@ -114,7 +114,7 @@ class MarkupField(models.TextField):
         super(MarkupField, self).__init__(verbose_name, name, **kwargs)
 
     def contribute_to_class(self, cls, name):
-        if not cls._meta.abstract:
+        if self.rendered_field and not cls._meta.abstract:
             choices = zip([''] + self.markup_choices_list,
                           ['--'] + self.markup_choices_list)
             markup_type_field = models.CharField(


### PR DESCRIPTION
Check on `contribute_to_class` whether we're running migrations.

Completes the work started in 49dee69ed673a4c2c28a0a9d8fdbe2e9a40faca2 which was based on https://bitbucket.org/carljm/django-markitup/src/652ce9bbcea8/markitup/fields.py#cl-120 but which lacked the condition to `contribute_to_class`.

TODO: Due to backwards incompatibility didn't rename the South introspection `rendered_field` -attribute even though it is used slightly unintuitively:

- outside South it's value is `True` (meaning that the rendered field should be created)
- when running South the introspection adds this `rendered_field=True` to keyword arguments, ultimately resulting in `some_markup_field.rendered_field` being `False`

(The original solution used `add_rendered_field` as the field attribute and `no_rendered_field` as the introspection attribute.)