### PR TITLE
Explicit Helper Fields (Rewrite to fix #20)

### DIFF
--- a/markupfield/fields.py
+++ b/markupfield/fields.py
@@ -1,5 +1,6 @@
 import django
 from django.conf import settings
+from django.core import checks
 from django.db import models
 from django.utils.safestring import mark_safe
 from django.utils.html import escape
@@ -8,46 +9,78 @@ from django.utils.encoding import smart_text
 from markupfield import widgets
 from markupfield import markup
 
-_rendered_field_name = lambda name: '_%s_rendered' % name
-_markup_type_field_name = lambda name: '%s_markup_type' % name
-
 # for fields that don't set markup_types: detected types or from settings
 _MARKUP_TYPES = getattr(settings, 'MARKUP_FIELD_TYPES',
                         markup.DEFAULT_MARKUP_TYPES)
 
 
 class Markup(object):
-
-    def __init__(self, instance, field_name, rendered_field_name,
-                 markup_type_field_name):
-        # instead of storing actual values store a reference to the instance
-        # along with field names, this makes assignment possible
+    def __init__(self, instance, field):
         self.instance = instance
-        self.field_name = field_name
-        self.rendered_field_name = rendered_field_name
-        self.markup_type_field_name = markup_type_field_name
+        self.field = field
 
-    # raw is read/write
+        # Initialize the convenience attributes.
+        self._update_rendered()
+
+    def _update_rendered(self):
+        # Update the rendered text.
+        if self.field.rendered_field:
+            setattr(
+                self.instance,
+                self.field.rendered_field,
+                self.field.markup_choices_dict[self.markup_type](
+                    escape(self.raw) if self.field.escape_html else self.raw
+                )
+            )
+        else:
+            self._rendered = (
+                self.field.markup_choices_dict[self.markup_type](
+                    escape(self.raw) if self.field.escape_html else self.raw
+                )
+            )
+
     def _get_raw(self):
-        return self.instance.__dict__[self.field_name]
+        return self.instance.__dict__[self.field.name]
 
     def _set_raw(self, val):
-        setattr(self.instance, self.field_name, val)
+        if val != self.raw:
+            self.instance.__dict__[self.field.name] = val
+            self._update_rendered()
 
     raw = property(_get_raw, _set_raw)
 
-    # markup_type is read/write
     def _get_markup_type(self):
-        return self.instance.__dict__[self.markup_type_field_name]
+        if self.field.markup_type_field:
+            return getattr(self.instance, self.field.markup_type_field)
+        if self.field.markup_type:
+            return self.field.markup_type
+        if self.field.default_markup_type:
+            return self.field.default_markup_type
+        return None
 
     def _set_markup_type(self, val):
-        return setattr(self.instance, self.markup_type_field_name, val)
+        if val != self.markup_type:
+            if self.field.markup_type_field:
+                if val not in self.field.markup_choices_list:
+                    raise ValueError(
+                        "Invalid default_markup_type for field '%s', "
+                        "allowed values: %s" % (
+                            self.field.name,
+                            ', '.join(self.field.markup_choices_list)
+                        )
+                    )
+                setattr(self.instance, self.field.markup_type_field, val)
+            else:
+                self.field.markup_type = val
+
+            self._update_rendered()
 
     markup_type = property(_get_markup_type, _set_markup_type)
 
-    # rendered is a read only property
     def _get_rendered(self):
-        return getattr(self.instance, self.rendered_field_name)
+        if self.field.rendered_field:
+            return getattr(self.instance, self.field.rendered_field)
+        return self._rendered
     rendered = property(_get_rendered)
 
     # allows display via templates to work without safe filter
@@ -58,101 +91,79 @@ class Markup(object):
 
 
 class MarkupDescriptor(object):
-
     def __init__(self, field):
         self.field = field
-        self.rendered_field_name = _rendered_field_name(self.field.name)
-        self.markup_type_field_name = _markup_type_field_name(self.field.name)
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance=None, owner=None):
         if instance is None:
-            raise AttributeError('Can only be accessed via an instance.')
+            raise AttributeError(
+                "The '%s' attribute can only be accessed from %s instances."
+                % (self.field.name, owner.__name__))
+
         markup = instance.__dict__[self.field.name]
         if markup is None:
             return None
-        return Markup(instance, self.field.name, self.rendered_field_name,
-                      self.markup_type_field_name)
 
-    def __set__(self, obj, value):
-        if isinstance(value, Markup):
-            obj.__dict__[self.field.name] = value.raw
-            setattr(obj, self.rendered_field_name, value.rendered)
-            setattr(obj, self.markup_type_field_name, value.markup_type)
+        return self.field.attr_class(instance, self.field)
+
+    def __set__(self, instance, value):
+        if isinstance(value, self.field.attr_class):
+            instance.__dict__[self.field.name] = value.raw
+
+            if self.field.rendered_field:
+                setattr(instance, self.field.rendered_field,
+                        value.rendered)
+            if self.field.markup_type_field:
+                setattr(instance, self.field.markup_type_field,
+                        value.markup_type)
         else:
-            obj.__dict__[self.field.name] = value
+            instance.__dict__[self.field.name] = value
 
 
 class MarkupField(models.TextField):
+    descriptor_class = MarkupDescriptor
+    attr_class = Markup
 
-    def __init__(self, verbose_name=None, name=None, markup_type=None,
-                 default_markup_type=None, markup_choices=_MARKUP_TYPES,
-                 escape_html=False, **kwargs):
-
-        if markup_type and default_markup_type:
-            raise ValueError('Cannot specify both markup_type and '
-                             'default_markup_type')
-
-        self.default_markup_type = markup_type or default_markup_type
-        self.markup_type_editable = markup_type is None
+    def __init__(self, markup_type=None, rendered_field=None,
+                 markup_type_field=None, default_markup_type=None,
+                 escape_html=False, markup_choices=_MARKUP_TYPES,
+                 *args, **kwargs):
+        self.markup_type = markup_type
+        self.rendered_field = rendered_field
+        self.markup_type_field = markup_type_field
+        self.default_markup_type = default_markup_type
         self.escape_html = escape_html
+        self.markup_choices = markup_choices
 
         self.markup_choices_list = [mc[0] for mc in markup_choices]
         self.markup_choices_dict = dict(markup_choices)
 
-        if (self.default_markup_type and
-                self.default_markup_type not in self.markup_choices_list):
-            raise ValueError("Invalid default_markup_type for field '%s', "
-                             "allowed values: %s" %
-                             (name, ', '.join(self.markup_choices_list)))
+        super(MarkupField, self).__init__(*args, **kwargs)
 
-        # for South FakeORM compatibility: the frozen version of a
-        # MarkupField can't try to add a _rendered field, because the
-        # _rendered field itself is frozen as well. See introspection
-        # rules below.
-        self.rendered_field = not kwargs.pop('rendered_field', False)
-
-        super(MarkupField, self).__init__(verbose_name, name, **kwargs)
-
-    def contribute_to_class(self, cls, name):
-        if not cls._meta.abstract:
-            choices = zip([''] + self.markup_choices_list,
-                          ['--'] + self.markup_choices_list)
-            markup_type_field = models.CharField(
-                max_length=30,
-                choices=choices, default=self.default_markup_type,
-                editable=self.markup_type_editable, blank=self.blank)
-            rendered_field = models.TextField(editable=False)
-            markup_type_field.creation_counter = self.creation_counter + 1
-            rendered_field.creation_counter = self.creation_counter + 2
-            cls.add_to_class(_markup_type_field_name(name), markup_type_field)
-            cls.add_to_class(_rendered_field_name(name), rendered_field)
-        super(MarkupField, self).contribute_to_class(cls, name)
-
-        setattr(cls, self.name, MarkupDescriptor(self))
+    def contribute_to_class(self, cls, name, virtual_only=False):
+        if django.VERSION < (1, 7):
+            super(MarkupField, self).contribute_to_class(cls, name)
+        else:
+            super(MarkupField, self).contribute_to_class(
+                cls, name, virtual_only=virtual_only
+            )
+        setattr(cls, self.name, self.descriptor_class(self))
 
     def pre_save(self, model_instance, add):
         value = super(MarkupField, self).pre_save(model_instance, add)
+
         if value.markup_type not in self.markup_choices_list:
-            raise ValueError('Invalid markup type (%s), allowed values: %s' %
-                             (value.markup_type,
-                              ', '.join(self.markup_choices_list)))
-        if self.escape_html:
-            raw = escape(value.raw)
-        else:
-            raw = value.raw
-        rendered = self.markup_choices_dict[value.markup_type](raw)
-        setattr(model_instance, _rendered_field_name(self.attname), rendered)
+            raise ValueError(
+                'Invalid markup type (%s), allowed values: %s' % (
+                    value.markup_type,
+                    ', '.join(self.markup_choices_list)
+                )
+            )
+
+        if self.field.rendered_field:
+            value._update_rendered()
+
         return value.raw
-
-    def get_prep_value(self, value):
-        if isinstance(value, Markup):
-            return value.raw
-        else:
-            return value
-
-    # copy get_prep_value to get_db_prep_value if pre-1.2
-    if django.VERSION < (1, 2):
-        get_db_prep_value = get_prep_value
 
     def value_to_string(self, obj):
         value = self._get_val_from_obj(obj)
@@ -165,19 +176,58 @@ class MarkupField(models.TextField):
         defaults.update(kwargs)
         return super(MarkupField, self).formfield(**defaults)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(MarkupField, self).deconstruct()
+
+        if self.markup_type:
+            kwargs['markup_type'] = self.markup_type
+        if self.rendered_field:
+            kwargs['rendered_field'] = self.rendered_field
+        if self.markup_type_field:
+            kwargs['markup_type_field'] = self.markup_type_field
+        if self.default_markup_type:
+            kwargs['default_markup_type'] = self.default_markup_type
+        if self.escape_html:
+            kwargs['escape_html'] = self.escape_html
+        kwargs['markup_choices'] = self.markup_choices
+
+        return name, path, args, kwargs
+
+    def _check_markup_type_vs_default_markup_type(self):
+        if self.markup_type and self.default_markup_type:
+            return [
+                checks.Error(
+                    ("Do not supply both 'markup_type' and "
+                     "'default_markup_type'."),
+                    obj=self,
+                )
+            ]
+        return []
+
+    def _check_default_markup_type_vs_markup_type_field(self):
+        if self.default_markup_type and self.markup_type_field:
+            return [
+                checks.Warning(
+                    ('The default markup type should be supplied to the '
+                     'markup type field, not to the MarkupField instance.'),
+                    obj=self,
+                    hint=(
+                        "Move your 'default_markup_type' parameter to the "
+                        "field you specified as your 'markup_type_field'."
+                    )
+                )
+            ]
+        return []
+
+    def check(self, **kwargs):
+        errors = super(MarkupField, self).check(**kwargs)
+        errors.extend(self._check_markup_type_vs_default_markup_type())
+        errors.extend(self._check_default_markup_type_vs_markup_type_field())
+        return errors
+
+
 # register MarkupField to use the custom widget in the Admin
 from django.contrib.admin.options import FORMFIELD_FOR_DBFIELD_DEFAULTS
 FORMFIELD_FOR_DBFIELD_DEFAULTS[MarkupField] = {
-    'widget': widgets.AdminMarkupTextareaWidget}
-
-# allow South to handle MarkupField smoothly
-try:
-    from south.modelsinspector import add_introspection_rules
-    # For a normal MarkupField, the add_rendered_field attribute is
-    # always True, which means no_rendered_field arg will always be
-    # True in a frozen MarkupField, which is what we want.
-    add_introspection_rules(rules=[
-        ((MarkupField, ), [], {'rendered_field': ['rendered_field', {}], })
-    ], patterns=['markupfield\.fields\.MarkupField'])
-except ImportError:
-    pass
+    'widget': widgets.AdminMarkupTextareaWidget
+}

--- a/markupfield/markup.py
+++ b/markupfield/markup.py
@@ -1,11 +1,18 @@
 from django.utils.html import escape, linebreaks, urlize
-from django.utils.functional import curry
 from django.conf import settings
 
+
 # build DEFAULT_MARKUP_TYPES
+def html(markup):
+    return markup
+
+
+def plain(markup):
+    return linebreaks(urlize(escape(markup)))
+
 DEFAULT_MARKUP_TYPES = [
-    ('html', lambda markup: markup),
-    ('plain', lambda markup: linebreaks(urlize(escape(markup)))),
+    ('html', html),
+    ('plain', plain),
 ]
 
 try:
@@ -51,8 +58,9 @@ try:
     if PYGMENTS_INSTALLED:
         try:
             from markdown.extensions.codehilite import makeExtension   # noqa
-            md_filter = curry(markdown.markdown,
-                              extensions=['codehilite(css_class=highlight)'])
+
+            def md_filter(markup):
+                return markdown.markdown(markup, extensions=['codehilite(css_class=highlight)'])
         except ImportError:
             pass
 
@@ -80,7 +88,9 @@ except ImportError:
 
 try:
     import textile
-    textile_filter = curry(textile.textile, encoding='utf-8', output='utf-8')
+
+    def textile_filter(markup):
+        return textile.textile(markup, encoding='utf-8', output='utf-8')
     DEFAULT_MARKUP_TYPES.append(('textile', textile_filter))
 except ImportError:
     pass


### PR DESCRIPTION
Fixes #20 

I have rewritten `MarkupField` to work with Django 1.7+ while remaining backward compatible with Django 1.6 and below. This follows the recommendations of Andrew Godwin but uses the original code as a strong template.

The interface accepts all old initializations with only a single difference: users will now have to either 1) specify an explicit `markup_type` in the field initialization or 2) specify an explicit `markup_type_field`. The days of being able to have an editable markup type without a dedicated and user-defined markup type field are over.

The field can still operate without a `rendered_field`, however. It will simply render the markup for every instance of the field if it cannot save it to the database. This supports old configurations, however, users can (and are encouraged to) specify a `rendered_field` at initialization which will save to the given field name.