### PR TITLE
Prevents duplicate migrations on markup_type_field

### DIFF
--- a/markupfield/fields.py
+++ b/markupfield/fields.py
@@ -124,7 +124,8 @@ class MarkupField(models.TextField):
             rendered_field = models.TextField(editable=False)
             markup_type_field.creation_counter = self.creation_counter + 1
             rendered_field.creation_counter = self.creation_counter + 2
-            cls.add_to_class(_markup_type_field_name(name), markup_type_field)
+            if not hasattr(_markup_type_field_name(name)):
+                cls.add_to_class(_markup_type_field_name(name), markup_type_field)
             cls.add_to_class(_rendered_field_name(name), rendered_field)
         super(MarkupField, self).contribute_to_class(cls, name)
 


### PR DESCRIPTION
    - Simply checking for the extistence of the field removes the issue
      of Django 1.7 migrations attempting to recreate the markup_type
      field