### PR TITLE
fix pass field default

### DIFF
--- a/markupfield/widgets.py
+++ b/markupfield/widgets.py
@@ -7,7 +7,7 @@ class MarkupTextarea(forms.widgets.Textarea):
 
     def render(self, name, value, attrs=None):
         if value is not None and not isinstance(value, six.text_type):
-            value = value.raw
+            value = getattr(value, 'raw', value)
         return super(MarkupTextarea, self).render(name, value, attrs)
 
 


### PR DESCRIPTION
on django 1.8 is there value from field default

	from django.utils.translation import ugettext_lazy as _
	from leonardo.module.web.models import Widget
	from markupfield.fields import MarkupField


	class MarkupTextWidget(Widget):
	    text = MarkupField(_('text'), blank=True, default=_(
	        'Empty text'), default_markup_type='restructuredtext')

	    class Meta:
	        abstract = True
	        verbose_name = _('markup text')
	        verbose_name_plural = _('markup texts')

raises exception value has no attribute raw