### PR TITLE
Tip for usage with default filter II.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,9 +186,9 @@ assignment to ``a.body_markup_type`` is equivalent to assignment to
     
         {{ a.body|default:"<missing body>" }}
     
-    That's because ``body`` is regular non-``None`` MarkupField instance. To let ``default`` or ``default_if_none`` filters to work evaluate ``rendered`` MarkupField attribute instead::
+    That's because ``body`` is regular non-``None`` MarkupField instance. To let ``default`` or ``default_if_none`` filters to work evaluate ``rendered`` MarkupField attribute instead. To prevent escaping HTML for the case ``rendered`` is truethy, finish chain with ``safe`` filter::
     
-        {{ a.body.rendered|default:"<missing body>" }} 
+        {{ a.body.rendered|default:"<missing body>"|safe }} 
 
 .. note::
     a.body.rendered is only updated when a.save() is called


### PR DESCRIPTION
Hi James!
As you state in the README, "rendered" attribute on Markup is of SafeText type. If "default" filter is applied to "rendered", output for browser is escaped - it displays HTML value, not interpret it as HTML. I've discovered that if I finish filter chain with "safe", HTML is not escaped.

Please keep in mind that I'm Django newbie and I'm unsure whether it's a bug or my misunderstanding of Django.