### PR TITLE
Copy default value to rendered field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Django Test folders/database
+markupfield/tests/migrations
+*.db

--- a/markupfield/fields.py
+++ b/markupfield/fields.py
@@ -125,7 +125,7 @@ class MarkupField(models.TextField):
                 blank=False if self.default_markup_type else True,
                 null=False if self.default_markup_type else True,
             )
-            rendered_field = models.TextField(editable=False, null=self.null)
+            rendered_field = models.TextField(editable=False, null=self.null, default=self.default)
             markup_type_field.creation_counter = self.creation_counter + 1
             rendered_field.creation_counter = self.creation_counter + 2
             cls.add_to_class(_markup_type_field_name(name), markup_type_field)

--- a/markupfield/tests/models.py
+++ b/markupfield/tests/models.py
@@ -42,3 +42,6 @@ class NullTestModel(models.Model):
 
 class DefaultTestModel(models.Model):
     text = MarkupField(null=True, default="**nice**", default_markup_type="markdown")
+
+class NullDefaultTestModel(models.Model):
+    text = MarkupField(null=False, blank=True, default="*nice*", default_markup_type="markdown")

--- a/markupfield/tests/tests.py
+++ b/markupfield/tests/tests.py
@@ -9,7 +9,7 @@ from django.utils.encoding import smart_text
 from markupfield.markup import DEFAULT_MARKUP_TYPES
 from markupfield.fields import MarkupField, Markup
 from markupfield.widgets import MarkupTextarea, AdminMarkupTextareaWidget
-from markupfield.tests.models import Post, Article, Concrete, NullTestModel, DefaultTestModel
+from markupfield.tests.models import Post, Article, Concrete, NullTestModel, DefaultTestModel, NullDefaultTestModel
 
 from django.forms.models import modelform_factory
 ArticleForm = modelform_factory(Article, fields=['normal_field', 'normal_field_markup_type',
@@ -347,6 +347,17 @@ class NullTestCase(TestCase):
 
 
 class DefaultTestCase(TestCase):
+    def test_default_value_rendered(self):
+        m = DefaultTestModel()
+        m.save()
+        
+        self.assertEqual(
+            m._meta.get_field('_text_rendered').default,
+            m._meta.get_field('text').default
+        )
+
+        self.assertEqual(m._text_rendered, "<p><strong>nice</strong></p>")
+
     def test_default_text_save(self):
         m = DefaultTestModel()
         m.save()
@@ -361,3 +372,18 @@ class DefaultTestCase(TestCase):
         self.assertEqual(smart_text(m.text), '')
         self.assertIsNone(m.text.raw)
         self.assertIsNone(m.text.rendered)
+
+
+class NullDefaultTestCase(TestCase):
+    def test_default_value_rendered(self):
+        m = NullDefaultTestModel()
+        m.save()
+        
+        self.assertEqual(
+            m._meta.get_field('_text_rendered').default,
+            m._meta.get_field('text').default
+        )
+
+        self.assertEqual(m._text_rendered, "<p><em>nice</em></p>")
+    
+


### PR DESCRIPTION
When altering a text field from `null=True` to `null=False` or adding a text field to an existing model that has `null=False`, a `default` must be provided. When altering from one of our existing models to use the `MarkupField` provided by this library, we ran into an issue where the migration could not be applied because the `_<field_name>_rendered` field was not supplied a `default`. 

Here is the sql error generated. The field and column names have been redacted:

```
pyodbc.ProgrammingError: ('42000', "[42000] [Microsoft][ODBC SQL Server Driver][SQL Server]ALTER TABLE only allows columns to be added that can contain nulls, or have a DEFAULT definition specified, or the column being added is an identity or timestamp column, or alternatively if none of the previous conditions are satisfied the table must be empty to allow addition of this column. Column '_<FIELD_NAME>_rendered' cannot be added to non-empty table '<TABLE_NAME>' because it does not satisfy these conditions. (4901) (SQLExecDirectW)")
```

This pull request aims to copy over the `default` from the `MarkupField` to the `_<field_name>_rendered` field so that migrations that alter existing fields/models will not error.