### PR TITLE
enable wagtail to index MarkupFields

### DIFF
--- a/markupfield/fields.py
+++ b/markupfield/fields.py
@@ -167,6 +167,13 @@ class MarkupField(models.TextField):
         else:
             return value
 
+    def get_searchable_content(self, value):
+        """
+        Wagtail uses this method to determine what value to index. Incoming value is the value returned by
+        model_instance.field_name
+        """
+        return self.get_prep_value(value)
+
     def value_to_string(self, obj):
         if obj is not None:
             value = self.value_from_object(obj)

--- a/markupfield/fields.py
+++ b/markupfield/fields.py
@@ -57,6 +57,9 @@ class Markup(object):
             return mark_safe('')
         return mark_safe(smart_text(self.rendered))
 
+    def get_searchable_content(self):
+        return self._get_raw()
+
     __str__ = __unicode__
 
 


### PR DESCRIPTION
wagtail checks for the existence of a [get_searchable_content](https://github.com/wagtail/wagtail/blob/1943d5a83c8a8a68345cf48bee9b739ad4001aad/wagtail/wagtailsearch/index.py#L206) method in Django fields to determine what value should be indexed in a search backend. This PR just delegates the implementation of this method to the existing `get_prep_value` method. 

Closes #46 