### PR TITLE
enables wagtail to index MarkupFields

### DIFF
--- a/markupfield/fields.py
+++ b/markupfield/fields.py
@@ -164,6 +164,12 @@ class MarkupField(models.TextField):
         else:
             return value
 
+    def get_searchable_content(self, value):
+        # Wagtail checks for existence of this method to determine what 
+        # value to index in its search backend. Incoming value comes from
+        # model_instance.field_name
+        return self.get_prep_value(value)
+
     def value_to_string(self, obj):
         if obj is not None:
             value = self.value_from_object(obj)


### PR DESCRIPTION
wagtail checks for the existence of a [get_searchable_content](https://github.com/wagtail/wagtail/blob/1943d5a83c8a8a68345cf48bee9b739ad4001aad/wagtail/wagtailsearch/index.py#L206) method in Django model fields to determine what value should be indexed in a search backend. This PR just delegates the implementation of this method to the existing `get_prep_value` method.

Closes #46