### PR TITLE
MarkupDescriptor: Return descriptor via class, not AttributeError

### DIFF
--- a/markupfield/fields.py
+++ b/markupfield/fields.py
@@ -69,7 +69,7 @@ class MarkupDescriptor(object):
 
     def __get__(self, instance, owner):
         if instance is None:
-            raise AttributeError('Can only be accessed via an instance.')
+            return self
         return Markup(instance, self.field.name, self.rendered_field_name,
                       self.markup_type_field_name)
 

--- a/markupfield/tests/tests.py
+++ b/markupfield/tests/tests.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from django.core import serializers
 from django.utils.encoding import smart_text
 from markupfield.markup import DEFAULT_MARKUP_TYPES
-from markupfield.fields import MarkupField, Markup
+from markupfield.fields import MarkupField, Markup, MarkupDescriptor
 from markupfield.widgets import MarkupTextarea, AdminMarkupTextareaWidget
 from markupfield.tests.models import (Post, Article, Concrete, NullTestModel, DefaultTestModel,
                                       NullDefaultTestModel)
@@ -381,3 +381,15 @@ class NullDefaultTestCase(TestCase):
         )
 
         self.assertEqual(m._text_rendered, "<p><em>nice</em></p>")
+
+
+class MarkupDescriptorTestCase(TestCase):
+
+    def test_class_access_returns_descriptor(self):
+        """
+        Accessing a markup field through the class returns the descriptor instance for the field.
+
+        (Regression test for issue #50.)
+        """
+        self.assertIsInstance(Post.body, MarkupDescriptor)
+        self.assertIs(Post._meta.get_field('body'), Post.body.field)


### PR DESCRIPTION
This changes MarkupDescriptor to return the descriptor instance when
accessed via a model class reference, rather than raising
AttributeError.

This follows the convention of other Django field descriptors, and fixes
compatibility with Django 2.1's admin list_display system checks.

See issue #50 (MarkupDescriptor breaks with Django 2.1's admin checks)