### PR TITLE
Updated support for more recent versions of Python and Django

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,13 @@ jobs:
       matrix:
         python: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         django: [ "3.2", "4.1", "4.2" ]
-      exclude:
-        - python: "3.11"
-          django: "3.2"
-        - python: "3.12"
-          django: "3.2"
-        - python: "3.12"
-          django: "4.1"
+        exclude:
+          - python: "3.11"
+            django: "3.2"
+          - python: "3.12"
+            django: "3.2"
+          - python: "3.12"
+            django: "4.1"
     steps:
       - name: checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         python: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-        django: [ "3.2", "4.1", "4.2" ]
+        django: [ "3.2", "4.1", "4.2", "5.0" ]
         database: [ "sqlite",  "postgres" ]
         exclude:
           - python: "3.11"
@@ -36,6 +36,10 @@ jobs:
             django: "3.2"
           - python: "3.12"
             django: "4.1"
+          - python: "3.8"
+            django: "5.0"
+          - python: "3.9"
+            django: "5.0"
     steps:
       - name: checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,27 @@ on:
 
 jobs:
   tests:
-    name: run tests for python ${{ matrix.python }}, django ${{ matrix.django }}
+    name: run tests for python ${{ matrix.python }}, django ${{ matrix.django }}, ${{ matrix.database }}
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: "test"
+          POSTGRES_USER: "test"
+          POSTGRES_PASSWORD: "test"
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     strategy:
       matrix:
         python: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         django: [ "3.2", "4.1", "4.2" ]
+        database: [ "sqlite",  "postgres" ]
         exclude:
           - python: "3.11"
             django: "3.2"
@@ -31,7 +46,7 @@ jobs:
       - name: install tox
         run: python3 -m pip install tox tox-gh
       - name: run tests
-        run: tox -e py${{ matrix.python }}-django${{ matrix.django }}
+        run: tox -e py${{ matrix.python }}-django${{ matrix.django }}-${{ matrix.database }}
 
   lint:
     name: check for any style errors

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,50 +7,43 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  tests:
+    name: run tests for python ${{ matrix.python }}, django ${{ matrix.django }}
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: 'test'
-          POSTGRES_PASSWORD: 'test'
-          POSTGRES_DB: 'test'
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
     strategy:
-      max-parallel: 4
       matrix:
-        python-version: [3.7, 3.9, '3.10']
-        db: ["sqlite", "postgres"]
-        django-version: [2.2, 3.2, "4.0b1"]
-        exclude:
-          - python-version: 3.7
-            db: sqlite
-            django-version: "4.0b1"
-          - python-version: 3.7
-            db: postgres
-            django-version: "4.0b1"
-
+        python: [ "3.8", "3.9", "3.10", "3.11" ]
+        django: [ "3.2", "4.1", "4.2" ]
+      exclude:
+        - python: "3.11"
+          django: "3.2"
+        - python: "3.12"
+          django: "3.2"
+        - python: "3.12"
+          django: "4.1"
     steps:
-    # Python & dependency installation
-    - uses: actions/checkout@v2
-    - name: setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: install dependencies
-      run: pip install --pre Django==${{ matrix.django-version }} markdown docutils psycopg2-binary
-    # - name: lint with flake8
-    #   run: flake8 --show-source --statistics --ignore=E203,E501,W503
-    - name: make executable
-      run: chmod a+x run_tests.sh
-    - name: run tests
-      run: ./run_tests.sh
+      - name: checkout repository
+        uses: actions/checkout@v4
+      - name: install python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: install tox
+        run: python3 -m pip install tox tox-gh
+      - name: run tests
+        run: tox -e py${{ matrix.python }}-django${{ matrix.django }}
+
+  lint:
+    name: check for any style errors
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+      - name: install python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: install tox
+        run: python3 -m pip install tox
+      - name: run linter
+        run: tox -e flake8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [ "3.8", "3.9", "3.10", "3.11" ]
+        python: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         django: [ "3.2", "4.1", "4.2" ]
       exclude:
         - python: "3.11"

--- a/markupfield/tests/settings.py
+++ b/markupfield/tests/settings.py
@@ -10,8 +10,10 @@ if os.environ.get("DB") == "postgres":
         "default": {
             "ENGINE": "django.db.backends.postgresql_psycopg2",
             "NAME": "test",
-            "USER": "postgres",
-            "PASSWORD": "",
+            "USER": "test",
+            "PASSWORD": "test",
+            "HOST": "127.0.0.1",
+            "PORT": "5432",
         }
     }
 else:

--- a/markupfield/tests/tests.py
+++ b/markupfield/tests/tests.py
@@ -386,7 +386,7 @@ class MarkupFieldFormSaveTests(TestCase):
         form.save()
 
         actual = Post.objects.get(title=self.data["title"])
-        self.assertEquals(actual.body.raw, self.data["body"])
+        self.assertEqual(actual.body.raw, self.data["body"])
 
     def test_form_update(self):
         existing = Post.objects.create(
@@ -404,7 +404,7 @@ class MarkupFieldFormSaveTests(TestCase):
         form.save()
 
         actual = Post.objects.get(title=update["title"])
-        self.assertEquals(actual.body.raw, update["body"])
+        self.assertEqual(actual.body.raw, update["body"])
 
 
 class MarkupFieldLocalFileTestCase(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py37-django{22,30}, flake8
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 --ignore=E402,E731 honeypot
+commands = flake8 --ignore=E402,W503,E731 markupfield
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py{38,39,310}-django3.2-{sqlite,postgres},
     py{38,39,310,311}-django4.1-{sqlite,postgres},
     py{38,39,310,311,312}-django4.2-{sqlite,postgres},
+    py{310,311,312}-django5.0-{sqlite,postgres},
     flake8
 
 [testenv:flake8]
@@ -21,6 +22,7 @@ deps =
     django3.2: Django ~= 3.2.9
     django4.1: Django ~= 4.1.3
     django4.2: Django ~= 4.2.0
+    django5.0: Django ~= 5.0.0
     markdown
     docutils
     psycopg2-binary

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,39 @@
 [tox]
-envlist = py37-django{22,30}, flake8
+envlist =
+    ; python releases: https://www.python.org/downloads/
+    ; django releases: https://www.djangoproject.com/download/
+    ; python+django support: https://docs.djangoproject.com/en/dev/faq/install/
+    py{38,39,310}-django3.2,
+    py{38,39,310,311}-django4.1,
+    py{38,39,310,311,312}-django4.2,
+    flake8
 
 [testenv:flake8]
 deps = flake8
 commands = flake8 --ignore=E402,W503,E731 markupfield
 
 [testenv]
+allowlist_externals =
+    ./run_tests.sh
+commands =
+    ./run_tests.sh
 deps =
-    django22: Django==2.2
-    django30: Django==3.0
+    django3.2: Django ~= 3.2.9
+    django4.1: Django ~= 4.1.3
+    django4.2: Django ~= 4.2.0
     markdown
     docutils
     psycopg2-binary
-commands = ./run_tests.sh
 pip_pre = True
 
 [flake8]
 max-line-length=99
+
+[gh]
+python =
+    ; https://github.com/tox-dev/tox-gh
+    3.8 = py38
+    3.9 = py39
+    3.10 = py310
+    3.11 = py311
+    3.12 = py312

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ envlist =
     ; python releases: https://www.python.org/downloads/
     ; django releases: https://www.djangoproject.com/download/
     ; python+django support: https://docs.djangoproject.com/en/dev/faq/install/
-    py{38,39,310}-django3.2,
-    py{38,39,310,311}-django4.1,
-    py{38,39,310,311,312}-django4.2,
+    py{38,39,310}-django3.2-{sqlite,postgres},
+    py{38,39,310,311}-django4.1-{sqlite,postgres},
+    py{38,39,310,311,312}-django4.2-{sqlite,postgres},
     flake8
 
 [testenv:flake8]
@@ -25,6 +25,9 @@ deps =
     docutils
     psycopg2-binary
 pip_pre = True
+setenv =
+    postgres: DB = postgres
+    sqlite: DB = sqlite
 
 [flake8]
 max-line-length=99


### PR DESCRIPTION
**This is currently still a work in progress, as discussed in #59. Do not merge yet!**

I've updated tox and the GitHub action to support more recent versions of Python and Django.
What is currently still planned:

- [x] add different databases to test matrix
- [x] add support for Django 5.0

Because services (like postgresql) are not supported yet by [act](https://github.com/nektos/act), I'll have to rely more on commits to test GHA workflows from now on.